### PR TITLE
Exclude sessions of type 'annex' in query to get closest session

### DIFF
--- a/repository/index.js
+++ b/repository/index.js
@@ -31,6 +31,7 @@ const getClosestMeeting = async (date) => {
 	PREFIX ext: <http://mu.semte.ch/vocabularies/ext/>
   PREFIX besluitvorming: <http://data.vlaanderen.be/ns/besluitvorming#>
   PREFIX dct: <http://purl.org/dc/terms/>
+  PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
 
   SELECT ?session ?meeting_id ?plannedstart ?agenda_id ?creationDate WHERE {
     GRAPH <${targetGraph}>


### PR DESCRIPTION
In kader van extra agenda voor Vlaamse Veerkracht:
- vergaderactiviteiten met een (sub)type van 'annex' uitsluiten bij het selecteren van de meest recente voorafgaande agenda

Zie ook https://github.com/kanselarij-vlaanderen/kaleidos-project/pull/153